### PR TITLE
feat(build): add /tk:build skill

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tk",
-  "description": "Spec-driven workflow for AI coding agents: PRD, plan, verify, and track features using tracer-bullet vertical slices.",
+  "description": "Spec-driven workflow for AI coding agents: PRD, plan, build, verify, and track features using tracer-bullet vertical slices.",
   "version": "1.18.3",
   "author": {
     "name": "Helder Burato Berto",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,16 @@ Named after the tracer-bullet technique from _The Pragmatic Programmer_: **Trace
 
 AI assistants work best with small, well-scoped tasks — not sprawling layers or flat task lists. TracerKit structures every feature as **tracer-bullet vertical slices**: each phase cuts through every layer (schema → service → API → UI → tests) and is demoable on its own. Integration problems surface early, not at the end.
 
-Three skills drive the workflow: **define** (`/tk:prd`), **plan** (`/tk:plan`), **verify** (`/tk:check`). The AI reads your specs directly, counts progress, and marks completed work done. Pure Markdown, zero runtime deps.
+Four skills drive the workflow: **define** (`/tk:prd`), **plan** (`/tk:plan`), **build** (`/tk:build`), **verify** (`/tk:check`). The AI reads your specs directly, counts progress, and marks completed work done. Pure Markdown, zero runtime deps.
+
+```
+DEFINE          PLAN           BUILD            VERIFY
+/tk:prd  ───▶  /tk:plan  ───▶  /tk:build  ───▶  /tk:check
+  │               │               │                 │
+  ▼               ▼               ▼                 ▼
+PRD doc       Phased plan    Implement phase    Pass/fail
+                              + feedback loops   + status
+```
 
 ## Get Started
 
@@ -111,7 +120,9 @@ AI:  Phase 1 — Theme visible end-to-end
      Written .tracerkit/plans/dark-mode-support.md
      Run `/tk:check dark-mode-support` when ready?
 
-You: # open the plan, implement each phase, write tests...
+You: /tk:build dark-mode-support
+AI:  Phase 1 — Theme visible end-to-end (3 remaining)
+     Implementing... all checks pass. Commit?
 
 You: /tk:check dark-mode-support
 AI:  Status: done | Total: 5/5
@@ -158,6 +169,7 @@ Direction is inferred from the current `storage` config. All artifacts are migra
 | ------------------ | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
 | `/tk:prd <idea>`   | Interview → codebase scan → structured PRD             | `.tracerkit/prds/<slug>.md` or GitHub Issue                                                     |
 | `/tk:plan <slug>`  | PRD → phased vertical slices, each demoable on its own | `.tracerkit/plans/<slug>.md` or GitHub Issue                                                    |
+| `/tk:build <slug>` | Implement next incomplete phase, run feedback loops    | Code changes + checked items in plan                                                            |
 | `/tk:brief`        | Feature dashboard with progress and suggested focus    | Terminal only, no files                                                                         |
 | `/tk:check [slug]` | Verify done-when checkboxes against codebase and tests | Verdict block in plan. On `done`: status updated (local) or issues closed + PRs linked (GitHub) |
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -2,11 +2,11 @@
 
 **No tool at all.** AI coding without specs means vague prompts and lost context between sessions. TracerKit adds structure without ceremony.
 
-**[Spec Kit](https://github.com/github/spec-kit)** (GitHub). Thorough but heavyweight: 5 phases, Python setup, rigid phase gates. TracerKit is 3 phases, zero runtime deps, automated verification.
+**[Spec Kit](https://github.com/github/spec-kit)** (GitHub). Thorough but heavyweight: 5 phases, Python setup, rigid phase gates. TracerKit is 4 phases, zero runtime deps, automated verification.
 
-**[Kiro](https://kiro.dev/)** (AWS). Powerful but locked to a dedicated IDE. TracerKit works inside Claude Code with pure Markdown skills.
+**[Kiro](https://kiro.dev/)** (AWS). Powerful but locked to a dedicated IDE. TracerKit works inside any AI coding agent with pure Markdown skills.
 
-**[OpenSpec](https://github.com/Fission-AI/OpenSpec)**. Similar philosophy, supports more AI tools. TracerKit trades breadth (Claude Code only) for depth: built-in skill discovery, automated verification, and fewer artifacts.
+**[OpenSpec](https://github.com/Fission-AI/OpenSpec)**. Similar philosophy, supports more AI tools. TracerKit offers built-in skill discovery, automated verification, phase-by-phase implementation, and fewer artifacts.
 
 ## Full comparison
 
@@ -14,8 +14,8 @@
 | ---------------- | ---------------- | -------------------------- | ---------------- | ----------------------------------- |
 | **What it is**   | CLI + extensions | Agentic IDE (VS Code fork) | Slash commands   | Markdown skills + lifecycle CLI     |
 | **Setup**        | Python + uv      | Dedicated IDE              | npm + init       | `npm install -g tracerkit`          |
-| **Phases**       | 5                | 3                          | 3                | 3 (prd, plan, check)                |
+| **Phases**       | 5                | 3                          | 3                | 4 (prd, plan, build, check)         |
 | **Artifacts**    | 4 files          | 3+ files                   | 4+ files         | 2 files (PRD, plan)                 |
 | **Verification** | Manual gates     | Diff approval              | Manual           | Automated (`done` or `in_progress`) |
 | **Runtime deps** | Python + uv      | Proprietary IDE            | None             | None (skills are pure Markdown)     |
-| **Tool lock-in** | Any AI assistant | Kiro IDE only              | Any AI assistant | Claude Code only                    |
+| **Tool lock-in** | Any AI assistant | Kiro IDE only              | Any AI assistant | Any AI coding agent                 |

--- a/docs/copilot-setup.md
+++ b/docs/copilot-setup.md
@@ -16,6 +16,7 @@ git clone https://github.com/helderberto/tracerkit.git
 mkdir -p .github/skills
 cp -r tracerkit/skills/prd .github/skills/tk-prd
 cp -r tracerkit/skills/plan .github/skills/tk-plan
+cp -r tracerkit/skills/build .github/skills/tk-build
 cp -r tracerkit/skills/check .github/skills/tk-check
 cp -r tracerkit/skills/brief .github/skills/tk-brief
 ```
@@ -59,6 +60,10 @@ Use the tk-prd skill to create a PRD for: add dark mode support
 
 ```
 Use the tk-plan skill to plan: dark-mode-support
+```
+
+```
+Use the tk-build skill to implement: dark-mode-support
 ```
 
 ```

--- a/docs/cursor-setup.md
+++ b/docs/cursor-setup.md
@@ -14,6 +14,7 @@ git clone https://github.com/helderberto/tracerkit.git
 mkdir -p .cursor/rules
 cp tracerkit/skills/prd/SKILL.md .cursor/rules/tk-prd.md
 cp tracerkit/skills/plan/SKILL.md .cursor/rules/tk-plan.md
+cp tracerkit/skills/build/SKILL.md .cursor/rules/tk-build.md
 cp tracerkit/skills/check/SKILL.md .cursor/rules/tk-check.md
 cp tracerkit/skills/brief/SKILL.md .cursor/rules/tk-brief.md
 ```
@@ -39,6 +40,10 @@ Follow the tk-prd rules to create a PRD for: add dark mode support
 
 ```
 Follow the tk-plan rules to plan the feature: dark-mode-support
+```
+
+```
+Follow the tk-build rules to implement the next phase of: dark-mode-support
 ```
 
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -2,7 +2,7 @@
 
 ## Full walkthrough
 
-A feature goes through three steps: define it (`/tk:prd`), plan it (`/tk:plan`), verify it (`/tk:check`). Optionally, start with `/tk:brief` to orient.
+A feature goes through four steps: define it (`/tk:prd`), plan it (`/tk:plan`), build it (`/tk:build`), verify it (`/tk:check`). Optionally, start with `/tk:brief` to orient.
 
 ```
 You: /tk:prd add dark mode support
@@ -53,10 +53,26 @@ AI:  Written .tracerkit/plans/dark-mode-support.md
      └
 ```
 
-Now you build. Open the plan, work through each phase: write code, run tests, ask Claude for help. TracerKit doesn't implement for you; it keeps the spec sharp so you (and your AI assistant) stay on track.
+Now build phase by phase. `/tk:build` picks the next incomplete phase, implements it, runs feedback loops, and offers to commit — one phase per invocation.
 
 ```
-You: # implement Phase 1, Phase 2, Phase 3...
+You: /tk:build dark-mode-support
+AI:  Phase 1 — Theme visible end-to-end (3 remaining)
+     Implementing... running feedback loops... all checks pass.
+     ┌ Phase 1 complete. Commit?
+     │ ● Yes, commit
+     │ ○ No, I'll review first
+     └
+
+You: /tk:build dark-mode-support
+AI:  Phase 2 — User can toggle and persist preference (2 remaining)
+     Implementing... all checks pass.
+     Committed. Run `/tk:build dark-mode-support` for Phase 3.
+
+You: /tk:build dark-mode-support
+AI:  Phase 3 — System preference auto-detected (2 remaining)
+     Implementing... all checks pass.
+     Committed. All phases complete — run `/tk:check dark-mode-support` to verify.
 
 You: /tk:check dark-mode-support
 AI:  Loading plan... Loading PRD... Running tests...
@@ -296,9 +312,22 @@ AI:  Created issue #43: [tk:plan] dark-mode-support: Plan: Add Dark Mode Support
      └
 ```
 
-After implementation:
+Build phase by phase, then verify:
 
 ```
+You: /tk:build dark-mode-support
+AI:  Phase 1 — Theme visible end-to-end (3 remaining)
+     Implementing... all checks pass. Committed.
+
+You: /tk:build dark-mode-support
+AI:  Phase 2 — User can toggle and persist preference (2 remaining)
+     Implementing... all checks pass. Committed.
+
+You: /tk:build dark-mode-support
+AI:  Phase 3 — System preference auto-detected (2 remaining)
+     Implementing... all checks pass. Committed.
+     All phases complete — run `/tk:check dark-mode-support` to verify.
+
 You: /tk:check dark-mode-support
 AI:  Loading plan from issue #43... Loading PRD from issue #42...
      Running tests...

--- a/docs/gemini-cli-setup.md
+++ b/docs/gemini-cli-setup.md
@@ -44,6 +44,7 @@ For always-loaded context, add skills to your project's `GEMINI.md`:
 
 @skills/prd/SKILL.md
 @skills/plan/SKILL.md
+@skills/build/SKILL.md
 @skills/check/SKILL.md
 @skills/brief/SKILL.md
 ```
@@ -58,6 +59,7 @@ Skills activate automatically based on intent:
 
 - "Create a PRD for dark mode" → `tk:prd`
 - "Plan the dark-mode-support feature" → `tk:plan`
+- "Implement the next phase of dark-mode-support" → `tk:build`
 - "Check if dark-mode-support is done" → `tk:check`
 - "Show me active features" → `tk:brief`
 

--- a/docs/metadata-lifecycle.md
+++ b/docs/metadata-lifecycle.md
@@ -37,7 +37,7 @@ These are the only statuses in TracerKit. The same vocabulary appears in the fea
 | ------------------ | ----------- | ---------------------------------------------------- |
 | Defined            | `/tk:prd`   | `created: 2025-06-15T14:30:00Z`<br>`status: created` |
 | Planning           | `/tk:plan`  | `status: in_progress`                                |
-| Implementation     | (user)      | no change (stays `in_progress`)                      |
+| Implementation     | `/tk:build` | no change (stays `in_progress`)                      |
 | Checked (partial)  | `/tk:check` | no change (stays `in_progress`)                      |
 | Checked (all pass) | `/tk:check` | `status: done`<br>`completed: 2025-06-20T09:00:00Z`  |
 
@@ -102,4 +102,4 @@ The plan file uses markdown checkboxes as progress markers:
 - [ ] Tests pass for service + API + component
 ```
 
-The AI assistant marks `[x]` during implementation. `/tk:check` verifies each item against the codebase and updates them. Progress is reported as checked/total (e.g. "2/4").
+`/tk:build` marks `[x]` during implementation. `/tk:check` verifies each item against the codebase and updates them. Progress is reported as checked/total (e.g. "2/4").

--- a/docs/opencode-setup.md
+++ b/docs/opencode-setup.md
@@ -21,7 +21,7 @@ cp -r tracerkit/skills/ .agents/skills/
 ```markdown
 # Workflow Skills
 
-When the user asks to define, plan, or verify a feature, use the matching skill:
+When the user asks to define, plan, build, or verify a feature, use the matching skill:
 
 | Intent                                 | Skill                   |
 | -------------------------------------- | ----------------------- |
@@ -54,6 +54,10 @@ Create a PRD for: add dark mode support
 
 ```
 Plan the dark-mode-support feature using vertical slices
+```
+
+```
+Implement the next phase of dark-mode-support
 ```
 
 ```

--- a/docs/opencode-setup.md
+++ b/docs/opencode-setup.md
@@ -27,6 +27,7 @@ When the user asks to define, plan, or verify a feature, use the matching skill:
 | -------------------------------------- | ----------------------- |
 | Define a feature, write a PRD          | `skills/prd/SKILL.md`   |
 | Plan implementation phases             | `skills/plan/SKILL.md`  |
+| Implement next phase                   | `skills/build/SKILL.md` |
 | Verify implementation, check progress  | `skills/check/SKILL.md` |
 | Session briefing, show active features | `skills/brief/SKILL.md` |
 
@@ -39,6 +40,7 @@ The agent evaluates each request and maps it to the appropriate skill:
 
 - "Create a PRD for auth" → reads and follows `skills/prd/SKILL.md`
 - "Plan the auth feature" → reads and follows `skills/plan/SKILL.md`
+- "Implement the next phase of auth" → reads and follows `skills/build/SKILL.md`
 - "Check if auth is done" → reads and follows `skills/check/SKILL.md`
 - "What's in progress?" → reads and follows `skills/brief/SKILL.md`
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tracerkit",
   "version": "1.18.3",
-  "description": "Spec-driven workflow for AI coding agents — PRD → plan → verify. Pure Markdown skills, zero runtime deps.",
+  "description": "Spec-driven workflow for AI coding agents — PRD → plan → build → verify. Pure Markdown skills, zero runtime deps.",
   "license": "MIT",
   "author": {
     "name": "helderberto",

--- a/skills/brief/SKILL.md
+++ b/skills/brief/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Session briefing — shows active features, progress, and suggested focus. Use at the start of a session to orient.
+description: Session briefing — shows active features, progress, and suggested focus. Use at the start of a session, when asking what to work on, or when checking active features.
 ---
 
 **Config**: read `.tracerkit/config.json` (default: `local`). Follow matching `<!-- if:local/github -->` blocks.

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -1,0 +1,188 @@
+---
+description: Implement one phase of a plan. Reads plan, finds next incomplete phase, implements it, runs feedback loops, marks checkboxes, offers commit. One phase per invocation.
+argument-hint: '<slug>'
+---
+
+**Config**: read `.tracerkit/config.json` (default: `local`). Follow matching `<!-- if:local/github -->` blocks.
+
+# Build Phase
+
+Implement the next incomplete phase of a plan — one phase per invocation.
+
+**Context window**: recommend `/clear` before starting to maximize token budget.
+
+**Interactive prompts**: present options as a numbered list and wait for the user's choice.
+
+## Pre-loaded context
+
+<!-- if:local -->
+
+- Available plans: !`ls .tracerkit/plans/*.md 2>/dev/null || echo "(none)"`
+  <!-- end:local -->
+  <!-- if:github -->
+- Available plans: list open GitHub Issues with label `{{github.labels.plan}}`
+<!-- end:github -->
+
+## Input
+
+The argument (if provided) is: $ARGUMENTS
+
+Use argument as `<slug>`. If empty, list available plans and ask the user to select one.
+
+Accepts slug or `@file` reference:
+
+```
+/tk:build dark-mode-support
+/tk:build @.tracerkit/plans/dark-mode-support.md
+```
+
+If argument starts with `@`, treat it as a file path — read that file directly as the plan.
+
+## Workflow
+
+### 1. Load the plan
+
+<!-- if:local -->
+
+Read `.tracerkit/plans/<slug>.md`. If missing, list plans and ask the user to select one.
+
+<!-- end:local -->
+<!-- if:github -->
+
+Find plan issue: open issue with label `{{github.labels.plan}}`, title matching `[{{github.labels.plan}}] <slug>:`. If missing, list plans and ask the user to select one.
+
+<!-- end:github -->
+
+### 2. Find the next incomplete phase
+
+Scan the plan for `## Phase N` headings. For each phase, count `- [ ]` and `- [x]` checkboxes.
+
+The **next incomplete phase** is the first phase that has at least one unchecked `- [ ]` item.
+
+If all phases are complete (zero unchecked items across all phases):
+
+> All phases complete. Run `/tk:check <slug>` to verify.
+
+Stop here.
+
+### 3. Present the phase
+
+Show the phase title and its unchecked items:
+
+```
+Phase N — <title> (M remaining)
+- [ ] First unchecked item
+- [ ] Second unchecked item
+```
+
+### 4. Offer a feature branch
+
+If on the default branch (main/master), ask:
+
+> Create branch `feat/<slug>`?
+> 1. Yes, create branch (Recommended)
+> 2. No, stay on current branch
+
+If accepted, create and switch to the branch.
+
+If already on a feature branch, skip this step.
+
+### 5. Implement the phase
+
+Work through each unchecked item in order. For each item:
+
+1. Read the plan's architectural decisions and the current item's context
+2. Explore relevant code to understand existing patterns and conventions
+3. Implement the change — follow the project's conventions (CLAUDE.md, linter config, test setup)
+4. Write tests alongside implementation (follow the project's existing test patterns)
+
+**Do not** impose coding rules, style, or conventions. Follow what the project already uses.
+
+**Do not** implement items from other phases. Stay within the current phase boundary.
+
+### 6. Run feedback loops
+
+After implementing the phase, detect and run available project scripts. Check `package.json` for these scripts (run only what exists):
+
+| Script pattern | Purpose |
+| --- | --- |
+| `typecheck`, `tsc`, `type-check` | Type checking |
+| `test`, `vitest`, `jest` | Tests |
+| `lint`, `eslint` | Linting |
+| `format:check`, `prettier --check` | Formatting |
+
+Run each detected script. If any fails:
+
+1. Read the error output
+2. Fix the issue
+3. Re-run the failing script
+4. Repeat until all pass (max 3 attempts per script)
+
+If a script still fails after 3 attempts, treat it as a **blocker** — pause and ask the user for help:
+
+> **Blocker**: `<script>` fails after 3 attempts.
+> Last error: `<error summary>`
+>
+> How to proceed?
+> 1. I'll fix it — pause and wait
+> 2. Skip this check and continue
+> 3. Abort this phase
+
+Wait for the user's response before continuing.
+
+### 7. Mark checkboxes
+
+After all feedback loops pass, update checkboxes in the plan file:
+
+<!-- if:local -->
+
+For each completed item, change `- [ ]` → `- [x]` in `.tracerkit/plans/<slug>.md`.
+
+<!-- end:local -->
+<!-- if:github -->
+
+For each completed item, change `- [ ]` → `- [x]` in the plan issue body using `gh issue edit`.
+
+<!-- end:github -->
+
+### 8. Offer commit
+
+Present the changes and ask:
+
+> Phase N complete — all checks pass. Commit?
+> 1. Yes, commit
+> 2. No, I'll review first
+
+If the user chooses to commit:
+
+1. Stage the implementation files (not `.tracerkit/` artifacts unless the project dogfoods TracerKit)
+2. Create a commit with a message following the project's commit conventions
+3. Confirm: "Committed. Run `/tk:build <slug>` for Phase N+1, or `/tk:check <slug>` to verify."
+
+If the user chooses to review:
+
+> Ready for review. Run `/tk:build <slug>` again when ready to continue.
+
+### 9. Blockers during implementation
+
+If implementation requires something the agent cannot provide (API key, external service, manual setup, design decision):
+
+> **Blocker**: <description of what's needed>
+>
+> How to proceed?
+> 1. I've resolved it — continue
+> 2. Skip this item for now
+> 3. Abort this phase
+
+Wait for the user's response. Never guess or work around a blocker silently.
+
+## Rules
+
+- **One phase per invocation** — never auto-advance to the next phase
+- **Never modify PRD content** — the PRD is read-only
+- **Never modify plan content** beyond marking checkboxes `[x]`
+- **Never skip a phase** — phases must be completed in order
+- **Never impose conventions** — follow the project's existing setup
+- **HITL at every decision point** — commits, blockers, and branch creation require user approval
+- **Feedback loops are mandatory** — always run available checks before marking items complete
+- **Do not push to remote** — only commit locally

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -80,6 +80,7 @@ Phase N — <title> (M remaining)
 If on the default branch (main/master), ask:
 
 > Create branch `feat/<slug>`?
+>
 > 1. Yes, create branch (Recommended)
 > 2. No, stay on current branch
 
@@ -104,12 +105,12 @@ Work through each unchecked item in order. For each item:
 
 After implementing the phase, detect and run available project scripts. Check `package.json` for these scripts (run only what exists):
 
-| Script pattern | Purpose |
-| --- | --- |
-| `typecheck`, `tsc`, `type-check` | Type checking |
-| `test`, `vitest`, `jest` | Tests |
-| `lint`, `eslint` | Linting |
-| `format:check`, `prettier --check` | Formatting |
+| Script pattern                     | Purpose       |
+| ---------------------------------- | ------------- |
+| `typecheck`, `tsc`, `type-check`   | Type checking |
+| `test`, `vitest`, `jest`           | Tests         |
+| `lint`, `eslint`                   | Linting       |
+| `format:check`, `prettier --check` | Formatting    |
 
 Run each detected script. If any fails:
 
@@ -124,6 +125,7 @@ If a script still fails after 3 attempts, treat it as a **blocker** — pause an
 > Last error: `<error summary>`
 >
 > How to proceed?
+>
 > 1. I'll fix it — pause and wait
 > 2. Skip this check and continue
 > 3. Abort this phase
@@ -150,6 +152,7 @@ For each completed item, change `- [ ]` → `- [x]` in the plan issue body using
 Present the changes and ask:
 
 > Phase N complete — all checks pass. Commit?
+>
 > 1. Yes, commit
 > 2. No, I'll review first
 
@@ -170,6 +173,7 @@ If implementation requires something the agent cannot provide (API key, external
 > **Blocker**: <description of what's needed>
 >
 > How to proceed?
+>
 > 1. I've resolved it — continue
 > 2. Skip this item for now
 > 3. Abort this phase

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -1,6 +1,6 @@
 ---
-description: Implement one phase of a plan. Reads plan, finds next incomplete phase, implements it, runs feedback loops, marks checkboxes, offers commit. One phase per invocation.
-argument-hint: '<slug>'
+description: Implement one phase of a plan. Reads plan, finds next incomplete phase, implements it, runs feedback loops, marks checkboxes, offers commit. One phase per invocation. Use when the user wants to implement, code, build, or work on the next phase of a plan.
+argument-hint: '[slug]'
 ---
 
 **Config**: read `.tracerkit/config.json` (default: `local`). Follow matching `<!-- if:local/github -->` blocks.

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -217,25 +217,11 @@ Carried forward from PRD verbatim.
 Gaps found in the PRD needing resolution. Blank if none.
 ```
 
-Print one line per phase: `Phase N — <title> (<condition summary>)`. Then ask: "What's next?" with options: "Start implementing" (Recommended) / "Run `/tk:check <slug>`" / "Done for now".
+Print one line per phase: `Phase N — <title> (<condition summary>)`. Then ask: "What's next?" with options: "Run `/tk:build <slug>`" (Recommended) / "Run `/tk:check <slug>`" / "Done for now".
 
 ## Execution guidance
 
-When implementing this plan, **always offer to create a feature branch** before writing any code. Ask: "Create branch `feat/<slug>`?" with options: "Yes, create branch" (Recommended) / "No, stay on current branch". If accepted, create the branch from the default branch.
-
-### During implementation
-
-Mark each "Done when" checkbox `[x]` **immediately after verifying** the condition.
-
-Always update the local plan file (`.tracerkit/plans/<slug>.md`): change `- [ ]` → `- [x]`. This file is the working copy for both local and GitHub modes.
-
-<!-- if:github -->
-
-**Sync to GitHub at phase boundaries**: after completing all items in a phase, update the plan issue body with `gh issue edit` to reflect the local state. This avoids per-item API calls.
-
-After all phases, open a PR with body containing `Closes #<prd-issue>, Closes #<plan-issue>`.
-
-<!-- end:github -->
+To implement this plan phase by phase, run `/tk:build <slug>`. It handles branch creation, implementation, feedback loops, checkbox marking, and commits — one phase per invocation.
 
 ## Rules
 

--- a/src/commands/init.test.ts
+++ b/src/commands/init.test.ts
@@ -56,7 +56,7 @@ describe('init', () => {
 
     const output = init(tmp.get());
 
-    expect(output.length).toBe(4);
+    expect(output.length).toBe(5);
   });
 
   it('reports each copied file with check prefix', () => {

--- a/src/commands/uninstall.test.ts
+++ b/src/commands/uninstall.test.ts
@@ -25,6 +25,7 @@ describe('uninstall', () => {
 
     expect(existsSync(join(tmp.get(), '.claude/skills/tk:prd'))).toBe(false);
     expect(existsSync(join(tmp.get(), '.claude/skills/tk:plan'))).toBe(false);
+    expect(existsSync(join(tmp.get(), '.claude/skills/tk:build'))).toBe(false);
     expect(existsSync(join(tmp.get(), '.claude/skills/tk:check'))).toBe(false);
   });
 
@@ -64,6 +65,9 @@ describe('uninstall', () => {
       true,
     );
     expect(output.some((l) => l.includes('✗') && l.includes('tk:plan'))).toBe(
+      true,
+    );
+    expect(output.some((l) => l.includes('✗') && l.includes('tk:build'))).toBe(
       true,
     );
     expect(output.some((l) => l.includes('✗') && l.includes('tk:check'))).toBe(

--- a/src/commands/update.test.ts
+++ b/src/commands/update.test.ts
@@ -88,7 +88,13 @@ describe('update', () => {
 
   it('outputs only warnings when all files are modified without force', () => {
     copyTemplates(tmp.get(), defaultConfig);
-    for (const name of ['tk:brief', 'tk:prd', 'tk:plan', 'tk:build', 'tk:check']) {
+    for (const name of [
+      'tk:brief',
+      'tk:prd',
+      'tk:plan',
+      'tk:build',
+      'tk:check',
+    ]) {
       writeFileSync(
         join(tmp.get(), `.claude/skills/${name}/SKILL.md`),
         'modified',

--- a/src/commands/update.test.ts
+++ b/src/commands/update.test.ts
@@ -83,12 +83,12 @@ describe('update', () => {
     const output = update(tmp.get());
 
     expect(output.every((l) => !l.includes('⚠'))).toBe(true);
-    expect(output.filter((l) => l.startsWith('✓'))).toHaveLength(4);
+    expect(output.filter((l) => l.startsWith('✓'))).toHaveLength(5);
   });
 
   it('outputs only warnings when all files are modified without force', () => {
     copyTemplates(tmp.get(), defaultConfig);
-    for (const name of ['tk:brief', 'tk:prd', 'tk:plan', 'tk:check']) {
+    for (const name of ['tk:brief', 'tk:prd', 'tk:plan', 'tk:build', 'tk:check']) {
       writeFileSync(
         join(tmp.get(), `.claude/skills/${name}/SKILL.md`),
         'modified',
@@ -98,7 +98,7 @@ describe('update', () => {
     const output = update(tmp.get());
 
     expect(output.filter((l) => l.startsWith('✓'))).toHaveLength(0);
-    expect(output.filter((l) => l.includes('⚠'))).toHaveLength(4);
+    expect(output.filter((l) => l.includes('⚠'))).toHaveLength(5);
   });
 
   it('removes deprecated skills', () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,7 @@ export const SKILL_NAMES = [
   `${SKILL_PREFIX}:brief`,
   `${SKILL_PREFIX}:prd`,
   `${SKILL_PREFIX}:plan`,
+  `${SKILL_PREFIX}:build`,
   `${SKILL_PREFIX}:check`,
 ] as const;
 export const DEPRECATED_SKILLS = [`${SKILL_PREFIX}:verify`] as const;

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -85,7 +85,13 @@ describe('copyTemplates', () => {
   it('leaves no unresolved placeholders in any template', () => {
     copyTemplates(tmp.get(), defaultConfig);
 
-    for (const skill of ['tk:brief', 'tk:prd', 'tk:plan', 'tk:build', 'tk:check']) {
+    for (const skill of [
+      'tk:brief',
+      'tk:prd',
+      'tk:plan',
+      'tk:build',
+      'tk:check',
+    ]) {
       const content = readFileSync(
         join(tmp.get(), `.claude/skills/${skill}/SKILL.md`),
         'utf8',
@@ -134,7 +140,13 @@ describe('copyTemplates', () => {
   it('skills contain storage config preamble', () => {
     copyTemplates(tmp.get(), defaultConfig);
 
-    for (const skill of ['tk:brief', 'tk:prd', 'tk:plan', 'tk:build', 'tk:check']) {
+    for (const skill of [
+      'tk:brief',
+      'tk:prd',
+      'tk:plan',
+      'tk:build',
+      'tk:check',
+    ]) {
       const content = readFileSync(
         join(tmp.get(), `.claude/skills/${skill}/SKILL.md`),
         'utf8',

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -19,8 +19,9 @@ describe('copyTemplates', () => {
     expect(result.copied).toContain('.claude/skills/tk:brief/SKILL.md');
     expect(result.copied).toContain('.claude/skills/tk:prd/SKILL.md');
     expect(result.copied).toContain('.claude/skills/tk:plan/SKILL.md');
+    expect(result.copied).toContain('.claude/skills/tk:build/SKILL.md');
     expect(result.copied).toContain('.claude/skills/tk:check/SKILL.md');
-    expect(result.copied).toHaveLength(4);
+    expect(result.copied).toHaveLength(5);
   });
 
   it('preserves file contents', () => {
@@ -151,7 +152,7 @@ describe('diffTemplates', () => {
   it('reports all files as missing on empty target', () => {
     const result = diffTemplates(tmp.get(), defaultConfig);
 
-    expect(result.missing).toHaveLength(4);
+    expect(result.missing).toHaveLength(5);
     expect(result.unchanged).toHaveLength(0);
     expect(result.modified).toHaveLength(0);
   });
@@ -160,7 +161,7 @@ describe('diffTemplates', () => {
     copyTemplates(tmp.get(), defaultConfig);
 
     const result = diffTemplates(tmp.get(), defaultConfig);
-    expect(result.unchanged).toHaveLength(4);
+    expect(result.unchanged).toHaveLength(5);
     expect(result.modified).toHaveLength(0);
     expect(result.missing).toHaveLength(0);
   });
@@ -194,7 +195,7 @@ describe('diffTemplates', () => {
       github: { ...DEFAULT_GITHUB },
     };
     const result = diffTemplates(tmp.get(), newConfig);
-    expect(result.modified).toHaveLength(4);
+    expect(result.modified).toHaveLength(5);
   });
 });
 

--- a/src/templates.test.ts
+++ b/src/templates.test.ts
@@ -85,7 +85,7 @@ describe('copyTemplates', () => {
   it('leaves no unresolved placeholders in any template', () => {
     copyTemplates(tmp.get(), defaultConfig);
 
-    for (const skill of ['tk:brief', 'tk:prd', 'tk:plan', 'tk:check']) {
+    for (const skill of ['tk:brief', 'tk:prd', 'tk:plan', 'tk:build', 'tk:check']) {
       const content = readFileSync(
         join(tmp.get(), `.claude/skills/${skill}/SKILL.md`),
         'utf8',
@@ -134,7 +134,7 @@ describe('copyTemplates', () => {
   it('skills contain storage config preamble', () => {
     copyTemplates(tmp.get(), defaultConfig);
 
-    for (const skill of ['tk:brief', 'tk:prd', 'tk:plan', 'tk:check']) {
+    for (const skill of ['tk:brief', 'tk:prd', 'tk:plan', 'tk:build', 'tk:check']) {
       const content = readFileSync(
         join(tmp.get(), `.claude/skills/${skill}/SKILL.md`),
         'utf8',


### PR DESCRIPTION
## Summary

Adds `/tk:build` — a phase-by-phase implementation driver that bridges the gap between `/tk:plan` and `/tk:check`. It reads a plan, finds the next incomplete phase, implements it, runs feedback loops (typecheck, test, lint, format), marks checkboxes, and offers to commit. One phase per invocation, human-in-the-loop at every decision point.

### What changed

**New skill** — `skills/build/SKILL.md`
- YAML frontmatter with `description` and `argument-hint`
- Config preamble + `<!-- if:local/github -->` conditional blocks
- Full workflow: load plan → find phase → implement → feedback loops → mark checkboxes → offer commit
- HITL pause points: branch creation, blockers (max 3 retries), commit approval
- Recommends `/clear` before starting for maximum context budget
- Accepts slug or `@file` reference

**Skill registration** — `src/constants.ts`
- `tk:build` added to `SKILL_NAMES` (between `plan` and `check`)

**Test updates** — all counts updated from 4 → 5 skills
- `templates.test.ts`: `copyTemplates` expects 5 files, `diffTemplates` reports 5, placeholder and preamble loops include `tk:build`
- `init.test.ts`: output length expects 5
- `update.test.ts`: unchanged/modified counts expect 5, "all modified" loop includes `tk:build`
- `uninstall.test.ts`: verifies `tk:build` directory removal

**Documentation** — all user-facing docs updated
- `README.md`: ASCII workflow diagram (DEFINE→PLAN→BUILD→VERIFY), skills table row, "four skills" intro, build step in example
- `docs/examples.md`: full `/tk:build` walkthrough in both local and GitHub sections
- `docs/comparison.md`: "4 phases", "Any AI coding agent" (was "Claude Code only")
- `docs/metadata-lifecycle.md`: implementation stage credits `/tk:build`
- `docs/cursor-setup.md`: `tk-build` copy + usage example
- `docs/copilot-setup.md`: `tk-build` copy + usage example
- `docs/gemini-cli-setup.md`: `tk:build` in skill list + intent mapping
- `docs/opencode-setup.md`: `tk:build` in intent table + usage example
- `.claude-plugin/plugin.json`: description includes "build"

**Skill quality improvements** (from audit)
- `build`: `argument-hint` uses `[slug]` (optional) matching plan/check convention
- `brief`: enriched description with more trigger phrases
- `plan`: replaced 17-line "Execution guidance" section with single `/tk:build` reference, "What's next?" suggests `/tk:build`

### Workflow is now 4 steps

```
DEFINE          PLAN           BUILD            VERIFY
/tk:prd  ───▶  /tk:plan  ───▶  /tk:build  ───▶  /tk:check
```

## Test plan

- [x] `npx vitest run` — 167 tests pass
- [x] `npx prettier --check .` — all files formatted
- [x] `tracerkit init` in temp dir produces `.claude/skills/tk:build/SKILL.md`
- [x] `/tk:check build-skill` — 24/24 checkboxes verified, zero blockers